### PR TITLE
inflect 7.0.0 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<38]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-build-isolation  --no-deps --ignore-installed -vv
 
 requirements:


### PR DESCRIPTION
inflect 7.0.0 rebuild

**Destination channel:** Defaults

### Links

- [PKG-10896]
- dev_url:        https://github.com/jazzband/inflect/tree/v7.0.0
- conda_forge:    https://github.com/conda-forge/inflect-feedstock
- pypi:           https://pypi.org/project/inflect/7.0.0
- pypi inspector: https://inspector.pypi.io/project/inflect/7.0.0

### Explanation of changes:

- - missing py3.14 for OSX, for some reason other platforms has versions 3.14 but not OSX


[PKG-10896]: https://anaconda.atlassian.net/browse/PKG-10896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ